### PR TITLE
move source code to code.cloudfoundry.org/service-metrics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "src/github.com/gogo/protobuf"]
 	path = src/github.com/gogo/protobuf
 	url = https://github.com/gogo/protobuf.git
-[submodule "src/github.com/cloudfoundry/service-metrics"]
-	path = src/github.com/cloudfoundry/service-metrics
-	url = https://github.com/cloudfoundry/service-metrics
 [submodule "src/github.com/codegangsta/cli"]
 	path = src/github.com/codegangsta/cli
 	url = https://github.com/codegangsta/cli
@@ -52,3 +49,6 @@
 [submodule "src/github.com/cloudfoundry/go-envstruct"]
 	path = src/github.com/cloudfoundry/go-envstruct
 	url = https://github.com/cloudfoundry/go-envstruct
+[submodule "src/code.cloudfoundry.org/service-metrics"]
+	path = src/code.cloudfoundry.org/service-metrics
+	url = https://github.com/cloudfoundry/service-metrics

--- a/packages/service-metrics/spec
+++ b/packages/service-metrics/spec
@@ -9,9 +9,9 @@ files:
   - code.cloudfoundry.org/go-loggregator/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/service-metrics/*.go # gosub
+  - code.cloudfoundry.org/service-metrics/metrics/*.go # gosub
   - github.com/cloudfoundry/go-envstruct/*.go # gosub
-  - github.com/cloudfoundry/service-metrics/*.go # gosub
-  - github.com/cloudfoundry/service-metrics/metrics/*.go # gosub
   - github.com/golang/protobuf/proto/*.go # gosub
   - github.com/golang/protobuf/ptypes/*.go # gosub
   - github.com/golang/protobuf/ptypes/any/*.go # gosub

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -31,7 +31,7 @@ pushd $(dirname $0)/..
     )
   }
 
-  sync_package service-metrics     -app github.com/cloudfoundry/service-metrics
+  sync_package service-metrics     -app code.cloudfoundry.org/service-metrics
   sync_package odb-service-adapter -app code.cloudfoundry.org/service-adapter
 
   wait


### PR DESCRIPTION
This PR moves `github.com/cloudfoundry/service-metrics` to `code.cloudfoundry.org/service-metrics` to match other Cloud Foundry projects.

[Related source code changes](https://github.com/cloudfoundry/service-metrics/pull/1)