### PR TITLE
Allow disabling service-metrics

### DIFF
--- a/jobs/service-metrics/monit
+++ b/jobs/service-metrics/monit
@@ -1,8 +1,10 @@
-<% p("service_metrics.monit_dependencies").length > 0 ? deps = "depends on #{p("service_metrics.monit_dependencies").join(', ')}" : deps = "" %>
-check process service-metrics
-  with pidfile /var/vcap/sys/run/bpm/service-metrics/service-metrics.pid
-  start program "/var/vcap/jobs/bpm/bin/bpm start service-metrics"
-  stop program "/var/vcap/jobs/bpm/bin/bpm stop service-metrics"
-  group vcap
-  <%= deps %>
+<% if p("service_metrics.execution_interval_seconds").to_i >= 0 %>
+  <% p("service_metrics.monit_dependencies").length > 0 ? deps = "depends on #{p("service_metrics.monit_dependencies").join(', ')}" : deps = "" %>
+  check process service-metrics
+    with pidfile /var/vcap/sys/run/bpm/service-metrics/service-metrics.pid
+    start program "/var/vcap/jobs/bpm/bin/bpm start service-metrics"
+    stop program "/var/vcap/jobs/bpm/bin/bpm stop service-metrics"
+    group vcap
+    <%= deps %>
+<% end %>
 


### PR DESCRIPTION
Pivotal RabbitMQ tile team have a use case for not enabling service-metrics. Our proposed solution is for Ops Manager to return a negative value when this is required.