### PR TITLE
bump golangci-lint configuration and action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "src/go.mod"
-      - uses: golangci/golangci-lint-action@v6.1.1
+      - uses: golangci/golangci-lint-action@v9
         with:
           args: --config .golangci.yml
           working-directory: src

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,19 +1,30 @@
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
     # Checks for non-ASCII identifiers
     - asciicheck
     # Computes and checks the cyclomatic complexity of functions.
     - gocyclo
-    # Inspects source code for security problems.
+    # Inspects source code for security problems.    
     - gosec
-
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Disable max issues per linter.
   max-issues-per-linter: 0
-  # Disable max same issues.
   max-same-issues: 0
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Description

Recent action runs for lint job against main fail due to the version of golangci-lint being too old.

* Migrated golangci-lint configuration to v2 using `golangci-lint migrate`   Retained comments for selected linters
* bump `golanci-lint-action` to current `v9`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
